### PR TITLE
[f] OUT-264 - When an unsubscribed users texts in START, RESUBSCRIBE, or DETROIT, we should resubscribe them and send the relevant reply

### DIFF
--- a/supabase/functions/deno.lock
+++ b/supabase/functions/deno.lock
@@ -1551,6 +1551,7 @@
     "https://deno.land/std@0.210.0/testing/_test_suite.ts": "30f018feeb3835f12ab198d8a518f9089b1bcb2e8c838a8b615ab10d5005465c",
     "https://deno.land/std@0.210.0/testing/asserts.ts": "605bbd2ef0695e2a4324d810c4ad22e56041d51afb9584fc0b4e81084b14b1d6",
     "https://deno.land/std@0.210.0/testing/bdd.ts": "c41f019786c4a9112aadb7e5a7bbcc711f58429ac5904b3855fa248ba5fa0ba6",
+    "https://deno.land/std@0.210.0/testing/mock.ts": "350211037129efa675592a3d7cdccbca3825000168ebebb3862a70b5af3b2f20",
     "https://deno.land/std@0.212.0/assert/assert.ts": "bec068b2fccdd434c138a555b19a2c2393b71dfaada02b7d568a01541e67cdc5",
     "https://deno.land/std@0.212.0/assert/assertion_error.ts": "9f689a101ee586c4ce92f52fa7ddd362e86434ffdf1f848e45987dc7689976b8",
     "https://deno.land/std@0.212.0/fmt/colors.ts": "71e2d7d9911cf3f4f8cceaabe588fd9a4c0228102f4233da62ffd3e421201de7",

--- a/supabase/functions/user-actions/handlers/twilio-message-handler.ts
+++ b/supabase/functions/user-actions/handlers/twilio-message-handler.ts
@@ -6,6 +6,7 @@ import { authors, twilioMessages } from '../drizzle/schema.ts'
 import { RequestBody } from '../types.ts'
 import { upsertAuthor, upsertConversation, upsertLabel, upsertRule } from './utils.ts'
 import { adaptTwilioMessage, adaptTwilioRequestAuthor } from '../adapters.ts'
+import { createPost } from '../services/missive.ts'
 
 const RESUBSCRIBED_TERMS = ['start', 'resubscribe', 'detroit']
 

--- a/supabase/functions/user-actions/index.ts
+++ b/supabase/functions/user-actions/index.ts
@@ -6,7 +6,7 @@ import { handleNewComment } from './handlers/comment-handler.ts'
 import { handleTeamChange } from './handlers/team-handler.ts'
 import { handleLabelChange } from './handlers/label-handler.ts'
 import { handleConversationAssigneeChange, handleConversationStatusChanged } from './handlers/conversation-handler.ts'
-import { handleTwilioMessage } from './handlers/twilio-message-handler.ts'
+import { handleResubscribe, handleTwilioMessage } from './handlers/twilio-message-handler.ts'
 import { verify } from './authentication.ts'
 import supabase from './database.ts'
 import { authenticationFailed } from './authentication.ts'
@@ -74,6 +74,7 @@ const handler = async (req: Request) => {
       case RuleType.IncomingTwilioMessage:
         await handleTwilioMessage(supabase, requestBody)
         await handleBroadcastReply(supabase, requestBody)
+        await handleResubscribe(supabase, requestBody)
         await refreshLookupCache(requestBody.conversation.id, requestBody.message!.references)
         break
       case RuleType.OutgoingTwilioMessage:

--- a/supabase/functions/user-actions/services/lookup.ts
+++ b/supabase/functions/user-actions/services/lookup.ts
@@ -5,7 +5,6 @@ import * as log from 'log'
 const refreshLookupCache = async (conversationId: string, references: string[]) => {
   const ref = references[0].replace(Deno.env.get('OUTLIER_PHONE_NUMBER')!, '')
   const url = `${Deno.env.get('LOOKUP_URL')!}/refresh-summary/${conversationId}?reference=${ref}`
-  log.info(`Refreshing lookup cache for ${url}, references: ${references}`)
 
   try {
     const response = await fetch(url, {
@@ -13,7 +12,9 @@ const refreshLookupCache = async (conversationId: string, references: string[]) 
         authorization: `Bearer ${Deno.env.get('LOOKUP_SECRET')!}`,
       },
     })
-    log.info(`refreshLookupCache response status: ${response.status}`)
+    if (!response.ok) {
+      log.error(`Failed to refreshLookupCache. conversationId: ${conversationId}`)
+    }
   } catch (error) {
     log.error(`refreshLookupCache error: ${error}`)
   }

--- a/supabase/functions/user-actions/tests/twilio-message-handler.test.ts
+++ b/supabase/functions/user-actions/tests/twilio-message-handler.test.ts
@@ -1,0 +1,87 @@
+import { describe, it } from 'https://deno.land/std@0.210.0/testing/bdd.ts'
+import { assertEquals } from 'https://deno.land/std@0.210.0/assert/mod.ts'
+import { eq } from 'drizzle-orm'
+
+import supabase from '../database.ts'
+import { authors } from '../drizzle/schema.ts'
+import { newIncomingSmsRequest } from './fixtures/incoming-twilio-message-request.ts'
+import { req } from './utils.ts'
+
+describe(
+  'Resubscribe',
+  { sanitizeOps: false, sanitizeResources: false },
+  () => {
+    it('successfully resubscribes an unsubscribed author', async () => {
+      const phoneNumber = '+11234567891'
+
+      await supabase.insert(authors).values({
+        phoneNumber,
+        unsubscribed: true,
+      })
+
+      const authorBefore = await supabase
+        .select()
+        .from(authors)
+        .where(eq(authors.phoneNumber, phoneNumber))
+      assertEquals(authorBefore[0].unsubscribed, true)
+
+      const resubscribeMsg = structuredClone(newIncomingSmsRequest)
+      resubscribeMsg.message!.preview = 'start11232'
+      resubscribeMsg.message!.from_field.id = phoneNumber
+
+      await req(JSON.stringify(resubscribeMsg))
+
+      const authorAfter = await supabase
+        .select()
+        .from(authors)
+        .where(eq(authors.phoneNumber, phoneNumber))
+      assertEquals(authorAfter[0].unsubscribed, false)
+    })
+
+    it('does nothing for already subscribed author', async () => {
+      const phoneNumber = '+11234567892'
+      const conversationId = 'test-conversation-id'
+
+      await supabase.insert(authors).values({
+        phoneNumber,
+        unsubscribed: false,
+      })
+
+      const resubscribeMsg = structuredClone(newIncomingSmsRequest)
+      resubscribeMsg.message!.preview = 'start'
+      resubscribeMsg.message!.from_field.id = phoneNumber
+      resubscribeMsg.conversation.id = conversationId
+
+      await req(JSON.stringify(resubscribeMsg))
+
+      const authorAfter = await supabase
+        .select()
+        .from(authors)
+        .where(eq(authors.phoneNumber, phoneNumber))
+      assertEquals(authorAfter[0].unsubscribed, false)
+    })
+
+    it('ignores non-resubscribe terms', async () => {
+      const phoneNumber = '+11234567893'
+      const conversationId = 'test-conversation-id'
+
+      await supabase.insert(authors).values({
+        phoneNumber,
+        unsubscribed: true,
+      })
+
+      const resubscribeMsg = structuredClone(newIncomingSmsRequest)
+      resubscribeMsg.message!.preview = 'hello'
+      resubscribeMsg.message!.from_field.id = phoneNumber
+      resubscribeMsg.conversation.id = conversationId
+
+      await req(JSON.stringify(resubscribeMsg))
+
+      const authorAfter = await supabase
+        .select()
+        .from(authors)
+        .where(eq(authors.phoneNumber, phoneNumber))
+      assertEquals(authorAfter[0].unsubscribed, true)
+    })
+  },
+)


### PR DESCRIPTION
[OUT-264](https://linear.app/pdw/issue/OUT-264/when-an-unsubscribed-users-texts-in-start-resubscribe-or-detroit-we)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a resubscription feature for authors via Twilio messages, allowing users to easily resubscribe by sending specific terms.
  
- **Bug Fixes**
  - Enhanced error handling for the lookup cache refresh process to improve reporting on failures.

- **Tests**
  - Added a comprehensive suite of unit tests for the new resubscription functionality, ensuring robust validation of various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->